### PR TITLE
fix: navegación mobile — ícono hamburguesa y dropdown Internacional

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -491,6 +491,20 @@
     display: flex;
   }
 
+  /* Keep the navbar opaque and above the sticky CTA bar while the menu is open.
+     backdrop-filter (added by .nav-scrolled on scroll) turns .nav into the
+     containing block for its fixed children, which shrank the full-screen
+     overlay to the 72px bar and let page content bleed through the open menu. */
+  .nav {
+    z-index: 1000;
+  }
+
+  .nav.nav-scrolled {
+    background: var(--bg-white) !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+
   .nav-links {
     position: fixed;
     top: 0;

--- a/css/components.css
+++ b/css/components.css
@@ -538,6 +538,33 @@
   .nav-links .nav-cta {
     background: #ffffff !important;
   }
+
+  /* Internacional dropdown: expand inline inside the mobile menu panel.
+     Touch devices have no :hover, so the submenu must be statically visible. */
+  .nav-dropdown {
+    width: 100%;
+  }
+
+  .nav-dropdown-toggle {
+    pointer-events: none;
+    font-weight: var(--font-semibold);
+  }
+
+  .nav-dropdown-toggle::after {
+    display: none;
+  }
+
+  .nav-dropdown-menu {
+    position: static;
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+    box-shadow: none;
+    background: transparent;
+    min-width: 0;
+    padding: 0 0 0 var(--space-3);
+    z-index: auto;
+  }
 }
 
 /* Fix: Ensure mobile menu always has solid background when navbar is scrolled */

--- a/servicios.html
+++ b/servicios.html
@@ -103,10 +103,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -115,7 +115,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="index.html" class="nav-link">Inicio</a>
           <a href="servicios.html" class="nav-link active" aria-current="page"
             >Servicios</a
@@ -646,22 +646,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -669,7 +669,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/tienda.html
+++ b/tienda.html
@@ -162,10 +162,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -174,7 +174,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="index.html" class="nav-link">Inicio</a>
           <a href="servicios.html" class="nav-link">Servicios</a>
           <a href="blog.html" class="nav-link">Blog</a>
@@ -643,22 +643,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -666,7 +666,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/belen.html
+++ b/ubicaciones/belen.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/caldas.html
+++ b/ubicaciones/caldas.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/copacabana.html
+++ b/ubicaciones/copacabana.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/el-poblado.html
+++ b/ubicaciones/el-poblado.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/envigado-centro.html
+++ b/ubicaciones/envigado-centro.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/estadio.html
+++ b/ubicaciones/estadio.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/itagui.html
+++ b/ubicaciones/itagui.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/la-estrella.html
+++ b/ubicaciones/la-estrella.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/laureles.html
+++ b/ubicaciones/laureles.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";

--- a/ubicaciones/sabaneta-centro.html
+++ b/ubicaciones/sabaneta-centro.html
@@ -122,10 +122,10 @@
         </a>
 
         <button
-          class="mobile-menú-btn"
+          class="mobile-menu-btn"
           aria-label="Abrir menú"
           aria-expanded="false"
-          aria-controls="nav-menú"
+          aria-controls="nav-menu"
         >
           <span></span>
           <span></span>
@@ -134,7 +134,7 @@
 
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
 
-        <div class="nav-links" id="nav-menú">
+        <div class="nav-links" id="nav-menu">
           <a href="../index.html" class="nav-link">Inicio</a>
           <a href="../servicios.html" class="nav-link">Servicios</a>
           <a href="../blog.html" class="nav-link">Blog</a>
@@ -413,22 +413,22 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const menúBtn = document.querySelector(".mobile-menú-btn");
+        const menuBtn = document.querySelector(".mobile-menu-btn");
         const navLinks = document.querySelector(".nav-links");
         const overlay = document.querySelector(".mobile-nav-overlay");
         const navbar = document.getElementById("navbar");
 
-        if (menúBtn && navLinks && overlay) {
-          menúBtn.addEventListener("click", function () {
-            const isExpanded = menúBtn.getAttribute("aria-expanded") === "true";
-            menúBtn.setAttribute("aria-expanded", String(!isExpanded));
+        if (menuBtn && navLinks && overlay) {
+          menuBtn.addEventListener("click", function () {
+            const isExpanded = menuBtn.getAttribute("aria-expanded") === "true";
+            menuBtn.setAttribute("aria-expanded", String(!isExpanded));
             navLinks.classList.toggle("active");
             overlay.classList.toggle("active");
             document.body.style.overflow = isExpanded ? "" : "hidden";
           });
 
           overlay.addEventListener("click", function () {
-            menúBtn.setAttribute("aria-expanded", "false");
+            menuBtn.setAttribute("aria-expanded", "false");
             navLinks.classList.remove("active");
             overlay.classList.remove("active");
             document.body.style.overflow = "";
@@ -436,7 +436,7 @@
 
           document.querySelectorAll(".nav-links a").forEach(function (link) {
             link.addEventListener("click", function () {
-              menúBtn.setAttribute("aria-expanded", "false");
+              menuBtn.setAttribute("aria-expanded", "false");
               navLinks.classList.remove("active");
               overlay.classList.remove("active");
               document.body.style.overflow = "";


### PR DESCRIPTION
## Problemas

Dos bugs de navegación en la versión mobile:

1. **Ícono del menú hamburguesa invisible** en varias páginas (`servicios.html`, `tienda.html`, `ubicaciones/*`).
2. **No se podía seleccionar "Internacional"** en mobile: el submenú no se desplegaba (`index.html`, `servicios.html`).

## Causas

1. Un reemplazo global "menu" → "menú" alteró nombres de **clases, IDs y selectores JS** (`mobile-menú-btn`, `nav-menú`, `menúBtn`). El CSS define `.mobile-menu-btn` sin tilde, así que el botón no recibía estilos.
2. El dropdown "Internacional" se mostraba solo con `:hover` / `:focus-within`. En dispositivos touch no hay hover, y no había JS ni override de CSS para mobile, así que el submenú quedaba oculto.

## Soluciones

1. Identificadores de código corregidos a su forma sin tilde, conservando el texto visible `aria-label="Abrir menú"`.
2. En la media query mobile, el `.nav-dropdown-menu` ahora se muestra **estático y expandido** dentro del panel del menú (sin depender de hover, sin JS). Se neutraliza el salto a `#` del toggle con `pointer-events: none`.

## Alcance

- HTML (ícono): `servicios.html`, `tienda.html`, `ubicaciones/{belen, caldas, copacabana, el-poblado, envigado-centro, estadio, itagui, la-estrella, laureles, sabaneta-centro}.html`
- CSS (dropdown): `css/components.css` — afecta `index.html` y `servicios.html`